### PR TITLE
adding a feature to link tickets to models in an existing application

### DIFF
--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -1593,6 +1593,11 @@ class TicketsController extends Controller
             $ticket->read_by_agent = 0;
         }
 
+        if (!empty($request->ticketable_type) && !empty($request->ticketable_id)) {
+            $ticket->ticketable_type = $request->ticketable_type;
+            $ticket->ticketable_id = $request->ticketable_id;
+        }
+
         $ticket->save();
 
         if (Setting::grab('ticket_attachments_feature')) {

--- a/src/Migrations/2021_05_11_092030_add_ticketable_columns_to_tickets_table.php
+++ b/src/Migrations/2021_05_11_092030_add_ticketable_columns_to_tickets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTicketableColumnsToTicketsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('panichd_tickets', function (Blueprint $table) {
+            $table->string('ticketable_type')->nullable();
+            $table->string('ticketable_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('panichd_tickets', function (Blueprint $table) {
+            $table->dropColumn(['ticketable_type', 'ticketable_id']);
+        });
+    }
+}

--- a/src/Traits/Ticketable.php
+++ b/src/Traits/Ticketable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PanicHD\PanicHD\Traits;
+
+trait Ticketable
+{
+
+    /**
+     * Returns all tickets for this model.
+     */
+    public function tickets()
+    {
+        return $this->morphMany('PanicHD\PanicHD\Models\Ticket', 'ticketable');
+    }
+
+}

--- a/src/Traits/Ticketable.php
+++ b/src/Traits/Ticketable.php
@@ -4,7 +4,6 @@ namespace PanicHD\PanicHD\Traits;
 
 trait Ticketable
 {
-
     /**
      * Returns all tickets for this model.
      */
@@ -12,5 +11,4 @@ trait Ticketable
     {
         return $this->morphMany('PanicHD\PanicHD\Models\Ticket', 'ticketable');
     }
-
 }

--- a/src/Views/tickets/createedit/form.blade.php
+++ b/src/Views/tickets/createedit/form.blade.php
@@ -21,6 +21,10 @@
             'id' => 'ticket_form',
             'enctype' => 'multipart/form-data'
         ]) !!}
+        @if (!empty(app('request')->input('ticketable_type')) && !empty(app('request')->input('ticketable_id')))
+            {!! CollectiveForm::hidden('ticketable_type', app('request')->input('ticketable_type')) !!}
+            {!! CollectiveForm::hidden('ticketable_id', app('request')->input('ticketable_id')) !!}
+        @endif
     @endif
 
         <legend>{!! isset($ticket) ? trans('panichd::lang.edit-ticket') . ' #'.$ticket->id : trans('panichd::lang.create-new-ticket') !!}</legend>

--- a/src/Views/tickets/show/body.blade.php
+++ b/src/Views/tickets/show/body.blade.php
@@ -70,6 +70,11 @@
 			<div class="col-xl-2 col-lg-3 col-md-4">
 				<p>
 				<strong>{{ trans('panichd::lang.ticket') }}</strong>{{ trans('panichd::lang.colon') . trans('panichd::lang.table-id') . $ticket->id }}
+				
+				@if (!empty($ticket->ticketable_type) && !empty($ticket->ticketable_id))
+					<br /><a href="{{ $setting->grab(strtolower(str_replace('\\', '.', $ticket->ticketable_type)).'.url').'/'.$ticket->ticketable_id }}">{{ $setting->grab(strtolower(str_replace('\\', '.', $ticket->ticketable_type)).'.text') }}</a>
+				@endif
+				
 				@if ($u->currentLevel() > 1 && $ticket->user_id != $ticket->creator_id)
 					<?php $creator_name = $ticket->creator_name == "" ? trans('panichd::lang.deleted-member') : (is_null($ticket->creator) ? $ticket->creator_name : $ticket->creator->name); ?>
 					<br /><strong>{{ trans('panichd::lang.show-ticket-creator') }}</strong>{{ trans('panichd::lang.colon') }}


### PR DESCRIPTION
From the view of your application from which you want to create a ticket linked to one of your models you add a link to the ticket creation form with the parameters as in the example below:

`<a href="{{ url('tickets/create?ticketable_type='.get_class($demo).'&ticketable_id=' . $demo->id) }}" >Create a ticket</a>`

it is necessary to fill in hidden fields in the ticket creation form to indicate the name of the model class and the ID that we want to link to the ticket

Add the Ticketable trait to the model of your application for which you want to enable tickets for:

```
use PanicHD\PanicHD\Traits\Ticketable;

class Demo extends Model
{
    use Ticketable;
}
```


In the controler you want to get tickets associated 

```
    public function show(Demo $demo)
    {
        ...
        $tickets = $demo->tickets()->get();
        return view('demos.show', compact('demo', 'tickets'));
    }
	
```


In the configuration settings of PanicHD in the tab "Other" you create two new settings that will be used to generate a link to the display of your object related to the ticket.

For example, for the App/demo model you need to create the settings below:

app.demo.url with the value "/demos" which will be used to generate the url 
app.demo.text with the text of the link that will be displayed in the ticket display as the value for example "link to the reference"

this will add on the ticket display page the link :

`<a href="/demos/{{$ticket->ticketable_id}}">link to the reference</a>`