### PR TITLE
Migrate refresh rename fix

### DIFF
--- a/src/Migrations/2017_12_17_185145_change_ticketit_tables_to_panichd.php
+++ b/src/Migrations/2017_12_17_185145_change_ticketit_tables_to_panichd.php
@@ -51,6 +51,10 @@ class ChangeTicketitTablesToPanichd extends Migration
     {
         Schema::rename('panichd_tickets', 'ticketit');
         foreach ($this->a_tables as $table) {
+            // Continue if the rename is already done
+            if (!Schema::hasTable('panichd_'.$table) && Schema::hasTable('ticketit_'.$table)) {
+                continue;
+            }
             Schema::rename('panichd_'.$table, 'ticketit_'.$table);
         }
     }


### PR DESCRIPTION
Fixes issue with `php artisan migrate:refresh`

```
Rolling back: 2017_12_17_185145_change_ticketit_tables_to_panichd
In Connection.php line 678:
                                                                               
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'documentation.pa  
  nichd_departments' doesn't exist (SQL: rename table `panichd_departments` t  
  o `ticketit_departments`)                                                    
                                                                               
[2021-06-08 11:30:01] testing.ERROR: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'documentation.panichd_departments' doesn't exist (SQL: rename table `panichd_departments` to `ticketit_departments`) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 42S02): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'documentation.panichd_departments' doesn't exist (SQL: rename table `panichd_departments` to `ticketit_departments`)
```